### PR TITLE
Remove redundant device parameter from Color constructors

### DIFF
--- a/bundles/org.eclipse.gmf.examples.runtime.diagram.logic/src/org/eclipse/gmf/examples/runtime/diagram/logic/internal/editparts/WireEditPart.java
+++ b/bundles/org.eclipse.gmf.examples.runtime.diagram.logic/src/org/eclipse/gmf/examples/runtime/diagram/logic/internal/editparts/WireEditPart.java
@@ -43,7 +43,7 @@ public WireEditPart(View view) {
 	super(view);
 }
 	
-public static final Color dead  = new Color(Display.getDefault(),0,0,0);
+public static final Color dead = new Color(0, 0, 0);
 
 public void activateFigure(){
 	super.activateFigure();

--- a/bundles/org.eclipse.gmf.examples.runtime.diagram.logic/src/org/eclipse/gmf/examples/runtime/diagram/logic/internal/figures/CircuitFigure.java
+++ b/bundles/org.eclipse.gmf.examples.runtime.diagram.logic/src/org/eclipse/gmf/examples/runtime/diagram/logic/internal/figures/CircuitFigure.java
@@ -49,7 +49,7 @@ public class CircuitFigure
 	 */
 	protected void paintFigure(Graphics graphics) {
 		Rectangle rect = getBounds().getCopy();
-		graphics.setBackgroundColor(new Color(null, 255, 255, 255));
+		graphics.setBackgroundColor(new Color(255, 255, 255));
 		graphics.fillRectangle(rect);
 	}
 }

--- a/bundles/org.eclipse.gmf.examples.runtime.diagram.logic/src/org/eclipse/gmf/examples/runtime/diagram/logic/internal/figures/LEDFigure.java
+++ b/bundles/org.eclipse.gmf.examples.runtime.diagram.logic/src/org/eclipse/gmf/examples/runtime/diagram/logic/internal/figures/LEDFigure.java
@@ -40,12 +40,12 @@ public class LEDFigure
 	/**
 	 * Color of the shadow around the LEDFigure's display
 	 */
-	public static final Color DISPLAY_SHADOW = new Color(null, 57, 117, 90); 
+	public static final Color DISPLAY_SHADOW = new Color(57, 117, 90); 
 
 	/**
 	 * Color of the LEDFigure's displayed value
 	 */
-	public static final Color DISPLAY_TEXT = new Color(null, 255, 199, 16);
+	public static final Color DISPLAY_TEXT = new Color(255, 199, 16);
 
 	protected String value;
 	

--- a/bundles/org.eclipse.gmf.examples.runtime.diagram.logic/src/org/eclipse/gmf/examples/runtime/diagram/logic/internal/figures/LogicColorConstants.java
+++ b/bundles/org.eclipse.gmf.examples.runtime.diagram.logic/src/org/eclipse/gmf/examples/runtime/diagram/logic/internal/figures/LogicColorConstants.java
@@ -20,18 +20,17 @@ import org.eclipse.swt.graphics.Color;
 /*
  * @canBeSeenBy org.eclipse.gmf.examples.runtime.diagram.logic.*
  */
-public interface LogicColorConstants
-{
+public interface LogicColorConstants {
 
-public final static Color andGate = new Color(null, 220,70,80);
-public final static Color orGate = new Color (null, 0, 134, 255);
-public final static Color xorGate = new Color (null, 240,240,40);
-public final static Color logicGreen = new Color(null, 123,174,148);
-public final static Color logicHighlight = new Color(null,66,166,115);
-public final static Color connectorGreen = new Color(null,0,69,40);
-public final static Color logicBackgroundBlue = new Color(null, 200, 200, 240);
-public final static Color ghostFillColor = new Color(null, 31, 31, 31);
-public final static Color logicBlack = new Color(null, 0, 0, 0);
-public final static Color displayText = new Color(null, 255, 199, 16);
+	public final static Color andGate = new Color(220, 70, 80);
+	public final static Color orGate = new Color(0, 134, 255);
+	public final static Color xorGate = new Color(240, 240, 40);
+	public final static Color logicGreen = new Color(123, 174, 148);
+	public final static Color logicHighlight = new Color(66, 166, 115);
+	public final static Color connectorGreen = new Color(0, 69, 40);
+	public final static Color logicBackgroundBlue = new Color(200, 200, 240);
+	public final static Color ghostFillColor = new Color(31, 31, 31);
+	public final static Color logicBlack = new Color(0, 0, 0);
+	public final static Color displayText = new Color(255, 199, 16);
 
 }

--- a/bundles/org.eclipse.gmf.runtime.common.ui/src/org/eclipse/gmf/runtime/common/ui/util/ConsoleUtil.java
+++ b/bundles/org.eclipse.gmf.runtime.common.ui/src/org/eclipse/gmf/runtime/common/ui/util/ConsoleUtil.java
@@ -62,13 +62,13 @@ public class ConsoleUtil {
 	//  error messages are red, warnings yellow and info blue.
 	
 	/** Default color used for logging error messages to the console. */
-	public final static Color DEFAULT_ERROR =  new Color(null,255,0,0);
+	public final static Color DEFAULT_ERROR =  new Color(255,0,0);
 	
 	/** Default color used for logging info messages to the console. */
-	public final static Color DEFAULT_INFO =  new Color(null,0,0,255);
+	public final static Color DEFAULT_INFO =  new Color(0,0,255);
 	
 	/** Default color used for logging warning messages to the console. */
-	public final static Color DEFAULT_WARNING =  new Color(null,255,255,0);
+	public final static Color DEFAULT_WARNING =  new Color(255,255,0);
 
 	/**
 	 * Registers the console with the Eclipse Console Manager.

--- a/bundles/org.eclipse.gmf.runtime.diagram.ui.printing/src/org/eclipse/gmf/runtime/diagram/ui/printing/internal/printpreview/PrintPreviewHelper.java
+++ b/bundles/org.eclipse.gmf.runtime.diagram.ui.printing/src/org/eclipse/gmf/runtime/diagram/ui/printing/internal/printpreview/PrintPreviewHelper.java
@@ -227,8 +227,7 @@ public class PrintPreviewHelper{
 	/**
 	 * the background color
 	 */
-	private static final Color BACKGROUND_COLOR = new Color(Display
-		.getDefault(), 124, 124, 124);
+	private static final Color BACKGROUND_COLOR = new Color(124, 124, 124);
 
 	/* Images */
 	/**

--- a/bundles/org.eclipse.gmf.runtime.diagram.ui/src/org/eclipse/gmf/runtime/diagram/ui/editparts/DiagramRootEditPart.java
+++ b/bundles/org.eclipse.gmf.runtime.diagram.ui/src/org/eclipse/gmf/runtime/diagram/ui/editparts/DiagramRootEditPart.java
@@ -828,7 +828,7 @@ public class DiagramRootEditPart
 	}
 
 	protected GridLayer createGridLayer(int r, int g, int b) {
-		return new GridLayerEx(new Color(null,r,g,b));
+		return new GridLayerEx(new Color(r,g,b));
 	}
 
 }

--- a/bundles/org.eclipse.gmf.runtime.diagram.ui/src/org/eclipse/gmf/runtime/diagram/ui/editpolicies/DragDropEditPolicy.java
+++ b/bundles/org.eclipse.gmf.runtime.diagram.ui/src/org/eclipse/gmf/runtime/diagram/ui/editpolicies/DragDropEditPolicy.java
@@ -51,7 +51,7 @@ public class DragDropEditPolicy extends GraphicalEditPolicy {
 	/**
 	 * the background feedback color
 	 */
-	private static final Color GRAY = new Color(null, 200, 200, 200);
+	private static final Color GRAY = new Color(200, 200, 200);
 
 	/**
 	 * the original background color

--- a/bundles/org.eclipse.gmf.runtime.draw2d.ui.render.awt/src/org/eclipse/gmf/runtime/draw2d/ui/render/awt/internal/graphics/Graphics2DToGraphicsAdaptor.java
+++ b/bundles/org.eclipse.gmf.runtime.draw2d.ui.render.awt/src/org/eclipse/gmf/runtime/draw2d/ui/render/awt/internal/graphics/Graphics2DToGraphicsAdaptor.java
@@ -235,8 +235,7 @@ public class Graphics2DToGraphicsAdaptor
 			
 			if (currentColor != null)
 				currentColor.dispose();
-			currentColor = new org.eclipse.swt.graphics.Color(
-				null, rgb.red, rgb.green, rgb.blue);
+			currentColor = new org.eclipse.swt.graphics.Color(rgb.red, rgb.green, rgb.blue);
 			swtGraphics.setBackgroundColor(currentColor);
 			swtGraphics.setForegroundColor(currentColor);
 			return true;

--- a/bundles/org.eclipse.gmf.runtime.draw2d.ui/src/org/eclipse/gmf/runtime/draw2d/ui/figures/FigureUtilities.java
+++ b/bundles/org.eclipse.gmf.runtime.draw2d.ui/src/org/eclipse/gmf/runtime/draw2d/ui/figures/FigureUtilities.java
@@ -56,11 +56,7 @@ public class FigureUtilities extends org.eclipse.draw2d.FigureUtilities {
 		if (i == null)
 			return null;
 		int color = i.intValue();
-		return new Color(
-			null,
-			(color & 0x000000FF),
-			(color & 0x0000FF00) >> 8,
-			(color & 0x00FF0000) >> 16);
+		return new Color((color & 0x000000FF), (color & 0x0000FF00) >> 8, (color & 0x00FF0000) >> 16);
 	}
 
 	/**

--- a/bundles/org.eclipse.gmf.tests.runtime.diagram.ui/src/org/eclipse/gmf/tests/runtime/diagram/ui/logic/LogicShapeTests.java
+++ b/bundles/org.eclipse.gmf.tests.runtime.diagram.ui/src/org/eclipse/gmf/tests/runtime/diagram/ui/logic/LogicShapeTests.java
@@ -79,7 +79,7 @@ public class LogicShapeTests extends AbstractShapeTests {
 		createPt.getTranslated(ledEP1.getFigure().getSize().getExpanded(100, 100));
 		
 		final LEDEditPart ledEP2 = (LEDEditPart)getLogicTestFixture().createShapeUsingTool(typeLED, createPt, getDiagramEditPart());
-		final Color red = new Color(null, 255, 0, 0);
+		final Color red = new Color(255, 0, 0);
 		final int fontHeight = 10;
 		
 		getLogicTestFixture().execute(new AbstractTransactionalCommand(getLogicTestFixture().getEditingDomain(), "", null) { //$NON-NLS-1$

--- a/bundles/org.eclipse.gmf.tests.runtime.draw2d.ui.render/src/org/eclipse/gmf/tests/runtime/draw2d/ui/render/internal/svg/SVGImageTest.java
+++ b/bundles/org.eclipse.gmf.tests.runtime.draw2d.ui.render/src/org/eclipse/gmf/tests/runtime/draw2d/ui/render/internal/svg/SVGImageTest.java
@@ -423,8 +423,7 @@ public class SVGImageTest
 	 * @return Color
 	 */
 	private Color integerToColor(int color) {
-		return new Color(null, (color & 0x00FF0000) >> 16,
-			(color & 0x0000FF00) >> 8, (color & 0x000000FF));
+		return new Color((color & 0x00FF0000) >> 16, (color & 0x0000FF00) >> 8, (color & 0x000000FF));
 	}
 
 	private static RGB BLACK = new RGB(0, 0, 0);


### PR DESCRIPTION
See https://github.com/eclipse-gef/gef-classic/pull/1086 and https://github.com/eclipse-platform/eclipse.platform.swt/pull/3233

Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
